### PR TITLE
using lightAccount instead of modularAccount in alchemy,added paymaster sponsorship in cli pimlico

### DIFF
--- a/packages/alchemy/nextJs/src/aaSDK/mintingService.ts
+++ b/packages/alchemy/nextJs/src/aaSDK/mintingService.ts
@@ -5,14 +5,14 @@ import { MpcAuthenticator, MpcSigner } from "@silencelaboratories/mpc-sdk";
 import { providers } from "ethers";
 import { ethersToAccount } from "./alchemyUtility";
 import { sepolia } from "@alchemy/aa-core";
-import { createModularAccountAlchemyClient } from "@alchemy/aa-alchemy";
+import { createLightAccountAlchemyClient } from "@alchemy/aa-alchemy";
 
 export async function mintAlchemyWallet(mpcAuth: MpcAuthenticator) {
     const provider = new providers.JsonRpcProvider("https://rpc.sepolia.org");
     const client = await MpcSigner.instance(mpcAuth, provider);
 
     const accountSigner = ethersToAccount(client);
-    const smartAccountClient = await createModularAccountAlchemyClient({
+    const smartAccountClient = await createLightAccountAlchemyClient({
         apiKey: process.env.API_KEY,
         chain: sepolia,
         signer: accountSigner,

--- a/packages/alchemy/nextJs/src/aaSDK/transactionService.ts
+++ b/packages/alchemy/nextJs/src/aaSDK/transactionService.ts
@@ -1,10 +1,9 @@
 // Copyright (c) Silence Laboratories Pte. Ltd.
 // This software is licensed under the Silence Laboratories License Agreement.
-
 import { providers } from "ethers";
 import { MpcAuthenticator, MpcSigner } from "@silencelaboratories/mpc-sdk";
 import { ethersToAccount } from "./alchemyUtility";
-import { createModularAccountAlchemyClient } from "@alchemy/aa-alchemy";
+import { createLightAccountAlchemyClient } from "@alchemy/aa-alchemy";
 import { sepolia } from "@alchemy/aa-core";
 import * as viem from "viem";
 
@@ -13,24 +12,23 @@ export async function sendTransaction(
     amount: string,
     mpcAuth: MpcAuthenticator
 ) {
-    const eoa = mpcAuth.accountManager.getEoa();
-    if (!eoa) {
-        throw new Error("Eoa not found");
-    }
-    const provider = new providers.JsonRpcProvider("https://rpc.sepolia.org");
-    const client = await MpcSigner.instance(mpcAuth, provider);
-    const accountSigner = ethersToAccount(client);
-    const smartAccountClient = await createModularAccountAlchemyClient({
-        apiKey: process.env.API_KEY,
-        chain: sepolia,
-        signer: accountSigner,
-    });
-
-    const requestData = {
-        to: recipientAddress,
-        value: convertEtherToWei(amount),
-    };
     try {
+        const eoa = mpcAuth.accountManager.getEoa();
+        if (!eoa) {
+            throw new Error("Eoa not found");
+        }
+        const provider = new providers.JsonRpcProvider("https://rpc.sepolia.org");
+        const client = await MpcSigner.instance(mpcAuth, provider);
+        const accountSigner = ethersToAccount(client);
+        const smartAccountClient = await createLightAccountAlchemyClient({
+            apiKey: process.env.API_KEY,
+            chain: sepolia,
+            signer: accountSigner,
+        });
+        const requestData = {
+            to: recipientAddress,
+            value: convertEtherToWei(amount),
+        };
         const uo = await smartAccountClient.sendUserOperation({
             uo: {
                 target: requestData.to as viem.Hex,
@@ -38,15 +36,15 @@ export async function sendTransaction(
                 value: requestData.value,
             },
         });
-
         const transactionHash =
             await smartAccountClient.waitForUserOperationTransaction(uo);
         return { transactionHash };
     } catch (error) {
-        console.error("Transaction error:", error);
-        return { success: false, error };
+        console.error("Transaction failed", error);
+        throw new Error(`Transaction failed: ${error}`);
     }
 }
+
 function convertEtherToWei(etherString: string) {
     const ether = Number(etherString);
     const weiString = (ether * 1e18).toString();

--- a/packages/pimlico/cli/scripts/simpleAccount/transfer.ts
+++ b/packages/pimlico/cli/scripts/simpleAccount/transfer.ts
@@ -62,6 +62,7 @@ export default async function main(t: string, amt: string) {
       `https://api.pimlico.io/v2/sepolia/rpc?apikey=${process.env.API_KEY}`
     ),
     middleware: {
+      sponsorUserOperation: paymasterClient.sponsorUserOperation, // optional
       gasPrice: async () =>
         (await pimlicoBundlerClient.getUserOperationGasPrice()).fast,
     },

--- a/packages/zerodev/cli/scripts/simpleAccount/transfer.ts
+++ b/packages/zerodev/cli/scripts/simpleAccount/transfer.ts
@@ -58,6 +58,9 @@ export default async function main(t: string, amt: string) {
 
   const response = account.address;
 
+  console.log(chalk.blue("account address:", response));
+  console.log(chalk.yellow("sending transaction..."));
+
   const requestData = {
     to: t as Hex,
     value: convertEtherToWei(amt),
@@ -68,14 +71,14 @@ export default async function main(t: string, amt: string) {
     entryPoint,
     chain: sepolia,
     bundlerTransport: http(
-      "https://rpc.zerodev.app/api/v2/bundler/521c47a3-535f-46db-ba5d-e0084aa0eedf"
+      `https://rpc.zerodev.app/api/v2/bundler/${process.env.API_KEY}`
     ),
     middleware: {
       sponsorUserOperation: async ({ userOperation }) => {
         const paymasterClient = createZeroDevPaymasterClient({
           chain: sepolia,
           transport: http(
-            "https://rpc.zerodev.app/api/v2/paymaster/521c47a3-535f-46db-ba5d-e0084aa0eedf"
+            `https://rpc.zerodev.app/api/v2/paymaster/${process.env.API_KEY}`
           ),
           entryPoint,
         });
@@ -87,17 +90,14 @@ export default async function main(t: string, amt: string) {
     },
   });
 
-  const userOpHash = await kernelClient.sendUserOperation({
-    userOperation: {
-      callData: await account.encodeCallData({
-        to: requestData.to,
-        value: requestData.value,
-        data: "0x",
-      }),
-    },
-  });
+  const txHash = await kernelClient.sendTransaction({
+    to: requestData.to,
+    value: requestData.value,
+    data: "0x123"
+});
 
-  console.log(chalk.blue("userOp hash:", userOpHash));
+
+  console.log(chalk.blue("transaction hash:", txHash));
 }
 
 function convertEtherToWei(etherString: string) {

--- a/packages/zerodev/nextJs/src/aaSDK/transactionService.ts
+++ b/packages/zerodev/nextJs/src/aaSDK/transactionService.ts
@@ -93,6 +93,7 @@ export async function sendTransaction(
         const txHash = await kernelClient.sendTransaction({
             to: requestData.to,
             value: requestData.value,
+            data: "0x123"
         });
 
         return { txHash };


### PR DESCRIPTION
- Using lightAccount instead of modularAccount in alchemy.

- Added paymaster sponsorship in CLI pimlico

- Replaced sendUserOp to sendTransaction in zerodev to avoid waiting for the userOp receipt([Link](https://docs.zerodev.app/sdk/core-api/send-transactions))